### PR TITLE
Readme: Await connection end in main

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ like this:
          :on-close (fn [{:keys [status reason]}] (prn status reason)))
 ```
 
+### main: wait until the connection is closed
+
+If you are starting the client from a `-main` function then you likely want to wait until the connection is closed before exiting from the function. (All the threads are started in the background and do not prevent main and thus the application from exiting.) You might do something like this:
+
+```clojure
+(defn -main []
+  (let [{:keys [events-publication dispatcher start]} (connect)]
+    ; ...
+    (let [c (sub-to-event events-publication :message #(msg-receiver dispatcher %))]
+      (loop []
+        (a/<!! c)
+        (recur)))))
+```
+
+Explanation: `sub-to-event` returns a channel that gets closed when the connection is closed.
+(You could also use `go-loop` or listen for the `:on-close` event ...)
+
 ## License
 
 Distributed under the WTFPL.


### PR DESCRIPTION
I think it is helpful to clearly communicate how to wait until the connection is closed before allowing the program to exit. (It took me some time to figure out why my application is exiting at once and how to prevent it.)

Feel free to propose a better way of doing this :-)

Thank you!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/casidiablo/slack-rtm/13)

<!-- Reviewable:end -->
